### PR TITLE
Automatically show N non-empty menu days instead of consecutive days

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a MagicMirror² module that displays school meal menus by fetching data from the LinqConnect API (formerly TitanSchools API at api.linqconnect.com). The module supports tracking multiple school menus simultaneously and can display breakfast and lunch items with configurable filtering.
+
+## Common Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Run all tests
+npm test
+
+# Run tests with Jest directly
+npx jest
+
+# Run specific test file
+npx jest test/unit/TitanSchoolsClient.test.js
+
+# Run integration tests
+npx jest test/integration/
+```
+
+## Architecture Overview
+
+### Three-Component System
+
+The module follows MagicMirror²'s standard architecture with three main components:
+
+1. **MMM-TitanSchoolMealMenu.js** (Frontend Module)
+   - Runs in the browser context
+   - Manages the DOM rendering and UI state
+   - Uses namespaced socket notifications to support multiple module instances
+   - Instance identification: `${buildingId}_${districtId}` allows multiple schools to be tracked simultaneously
+   - Handles loading states, error states, and retry logic with configurable delays
+
+2. **node_helper.js** (Backend Helper)
+   - Runs in Node.js context
+   - Manages multiple `TitanSchoolsClient` instances (one per school being tracked)
+   - Coordinates between frontend instances and their corresponding API clients
+   - Calculates date ranges based on `displayCurrentWeek` and `weekStartsOnMonday` settings
+   - Uses non-namespaced `TITANSCHOOLS_SET_CONFIG` notification for initial setup, then namespaced notifications thereafter
+
+3. **TitanSchoolsClient.js** (API Client)
+   - Lightweight client for LinqConnect API endpoint: `https://api.linqconnect.com/api/FamilyMenu`
+   - Requires `buildingId` and `districtId` as mandatory parameters
+   - Date format requirement: API expects dates as `m-d-Y` (e.g., `12-5-2021`)
+   - Two-step data processing:
+     - `extractMenusByDate()`: Normalizes raw API response into breakfast/lunch arrays
+     - `processData()`: Combines data with relative date labels (Today, Tomorrow, day names)
+
+### Key Design Patterns
+
+**Multi-Instance Support**: The notification system uses a namespacing pattern `TITANSCHOOLS_{ACTION}::{instanceName}` where instanceName combines buildingId and districtId. This allows multiple module instances to coexist without interference.
+
+**Recipe Category Filtering**: The API returns meals organized by `RecipeCategories` (Entrees, Grain, Fruit, Vegetable, Milk, Condiment, Extra). The `recipeCategoriesToInclude` config controls which categories are displayed. Empty array means show all categories.
+
+**Date Label Generation**: The `upcomingRelativeDates()` function generates human-friendly labels (Today, Tomorrow, or day of week) for the configured number of days to display.
+
+**Error Handling**: API errors are categorized as 500-level (service unavailable) or 400-level (bad request/config issue). The module retries failed requests after `retryDelayMs`.
+
+## API Response Structure
+
+The LinqConnect API returns data in this shape:
+- `FamilyMenuSessions[]` - Contains separate sessions for breakfast and lunch
+  - `ServingSession` - String matching "breakfast" or "lunch" (case-insensitive)
+  - `MenuPlans[0].Days[]` - Array of daily menus
+    - `Date` - Date string
+    - `MenuMeals[].RecipeCategories[].Recipes[]` - Nested structure of meal items
+      - `CategoryName` - Used for filtering (Entrees, Grain, etc.)
+      - `RecipeName` - Actual food item name
+
+## Configuration
+
+Required fields: `buildingId`, `districtId`
+
+Optional but commonly customized:
+- `numberOfDaysToDisplay` (default: 3) - How many days ahead to show
+- `recipeCategoriesToInclude` (default: ["Entrees", "Grain"]) - Which food categories to display
+- `updateIntervalMs` (default: 3600000) - How often to refresh data
+- `displayCurrentWeek` (default: false) - Start from beginning of week instead of today
+- `hideEmptyDays` / `hideEmptyMeals` (default: false) - Control visibility of days/meals without data
+- `debug` (default: false) - Enable verbose logging
+
+## Testing
+
+Tests are organized into:
+- `test/unit/` - Unit tests for TitanSchoolsClient data processing
+- `test/integration/` - Tests verifying API response shape
+- `test/unit/mocks/mockApiResponse.js` - Mock data for testing without API calls
+
+The `TitanSchoolsClient` has a `fetchMockMenu()` method that uses mock data for testing.
+
+## Finding buildingId and districtId
+
+Users need to inspect network requests on linqconnect.com to find their school's IDs in the query string parameters of requests to `/FamilyMenu`. These UUIDs are required for the module to function.

--- a/MMM-TitanSchoolMealMenu.js
+++ b/MMM-TitanSchoolMealMenu.js
@@ -135,7 +135,7 @@ Module.register("MMM-TitanSchoolMealMenu", {
           breakfastMenuRecipes.innerHTML = dayMenu.breakfast ?? "none";
           breakfastMenuRecipes.className = "meal-recipes";
 
-          breakfastMenuList.className = "meal-description";
+          breakfastMenuList.className = "meal-description breakfast-description";
           breakfastMenuList.appendChild(breakfastMenuItems);
           breakfastMenuItems.appendChild(breakfastMenuTitle);
           breakfastMenuItems.appendChild(breakfastMenuRecipes);
@@ -154,7 +154,7 @@ Module.register("MMM-TitanSchoolMealMenu", {
           lunchMenuRecipes.innerHTML = dayMenu.lunch ?? "none";
           lunchMenuRecipes.className = "meal-recipes";
 
-          lunchMenuList.className = "meal-description";
+          lunchMenuList.className = "meal-description lunch-description";
           lunchMenuList.appendChild(lunchMenuItems);
           lunchMenuItems.appendChild(lunchMenuTitle);
           lunchMenuItems.appendChild(lunchMenuRecipes);

--- a/MMM-TitanSchoolMealMenu.js
+++ b/MMM-TitanSchoolMealMenu.js
@@ -107,6 +107,15 @@ Module.register("MMM-TitanSchoolMealMenu", {
       console.log(this.dataNotification);
       const wrapperDataNotification = document.createElement("div");
 
+      // Check if we have any menu data to display
+      if (this.dataNotification.length === 0) {
+        const noMenuMessage = document.createElement("div");
+        noMenuMessage.className = `small dimmed ${this.config.size || ""}`;
+        noMenuMessage.innerHTML = "No menu available for the upcoming days";
+        wrapper.appendChild(noMenuMessage);
+        return wrapper;
+      }
+
       const meals = document.createElement("ul");
       meals.className = `meal-list ${this.config.size || ""}`;
       this.dataNotification.forEach((dayMenu, index) => {

--- a/TitanSchoolsClient.js
+++ b/TitanSchoolsClient.js
@@ -255,7 +255,9 @@ class TitanSchoolsClient {
   processData(data) {
     const menus = this.extractMenusByDate(data);
 
-    const upcomingMenuByDate = upcomingRelativeDates(this.numberOfDaysToDisplay).map((day) => {
+    // Generate extra days as buffer to ensure we have enough non-empty days
+    const bufferDays = this.numberOfDaysToDisplay + 7;
+    const allUpcomingDays = upcomingRelativeDates(bufferDays).map((day) => {
       // day = { date: '9-6-2021', label: 'Today' }; // Possible labels: 'Today', 'Tomorrow', or a day of the week
       const breakfastAndLunchForThisDay = menus.reduce(
         (menuByMealTime, menu) => {
@@ -285,6 +287,14 @@ class TitanSchoolsClient {
         lunch: breakfastAndLunchForThisDay.lunch,
       };
     });
+
+    // Filter to keep only days with at least some menu data (breakfast OR lunch)
+    const nonEmptyDays = allUpcomingDays.filter(
+      (day) => day.breakfast || day.lunch
+    );
+
+    // Return only the requested number of non-empty days
+    const upcomingMenuByDate = nonEmptyDays.slice(0, this.numberOfDaysToDisplay);
 
     console.log(
       `School meal info from titanschools API: ${JSON.stringify(

--- a/node_helper.js
+++ b/node_helper.js
@@ -27,7 +27,8 @@ module.exports = NodeHelper.create({
       : new Date(Date.now());
 
     var endDate = new Date(Date.now());
-    endDate.setDate(startDate.getDate() + this.config.numberOfDaysToDisplay);
+    // Request extra days as a buffer to ensure we have enough non-empty days to display
+    endDate.setDate(startDate.getDate() + this.config.numberOfDaysToDisplay + 7);
 
     try {
       //   const menu = await this.titanSchoolsClient.fetchMockMenu();


### PR DESCRIPTION
## Summary

Fixes the issue where the module shows blank/empty days on weekends. When `numberOfDaysToDisplay` is set to 2 on a Saturday, the module previously showed Saturday and Sunday (both with "none" for breakfast/lunch). Now it automatically skips empty days and shows the next 2 days with actual menu data (e.g., Monday and Tuesday).

## Changes

- **node_helper.js**: Request extra buffer days from API (numberOfDaysToDisplay + 7) to ensure we fetch enough data
- **TitanSchoolsClient.js**: Filter results in `processData()` to return only days with menu data (breakfast OR lunch exists)
- **MMM-TitanSchoolMealMenu.js**: Display "No menu available for the upcoming days" message when all fetched days are empty (e.g., during long holiday breaks)
- **CLAUDE.md**: Added codebase documentation for future development

## Benefits

- Works for weekends AND unexpected closures/holidays automatically
- No hardcoded weekend logic - relies on what the API returns
- Backwards compatible - existing configs will work better automatically
- Handles edge cases like long holiday breaks with appropriate messaging

## Testing

Tested with different scenarios to ensure proper behavior across various configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)